### PR TITLE
fix: update gpuIds to ADA_24

### DIFF
--- a/.runpod/hub.json
+++ b/.runpod/hub.json
@@ -7,7 +7,7 @@
   "config": {
     "runsOn": "GPU",
     "containerDiskInGb": 5,
-    "gpuIds": "NVIDIA GeForce RTX 4090",
+    "gpuIds": "ADA_24",
     "gpuCount": 1,
     "allowedCudaVersions": [
       "12.7",


### PR DESCRIPTION
### Motivation

- Updated gpuIds value from 'NVIDIA GeForce RTX 4090' to 'ADA_24' in .runpod/hub.json to align with RunPod's GPU naming convention
- This change ensures proper GPU selection when deploying the worker template

### Issues closed

No specific issues were referenced for this change.